### PR TITLE
Fix alias and page title typo

### DIFF
--- a/src/pages/ProfessorRating.tsx
+++ b/src/pages/ProfessorRating.tsx
@@ -149,7 +149,7 @@ const ProfessorRating = () => {
 
       // En ambos componentes, añadir este useEffect
       useEffect(() => {
-        document.title = `ProfeScore - Califcación`;
+        document.title = `ProfeScore - Calificación`;
 
         const mainElement = document.getElementById('main-content');
         if (mainElement) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss(),],
   resolve: {
     alias: {
-      'a': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url))
     }
   }
 })


### PR DESCRIPTION
## Summary
- fix alias in `vite.config.ts`
- fix professor rating page title typo

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ad8c4b7e883288dd14e1323b4f259