### PR TITLE
Add Vitest setup and toast reducer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@fingerprintjs/fingerprintjs-pro-react": "^2.6.3",
@@ -50,6 +51,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/hooks/__tests__/use-toast.test.ts
+++ b/src/hooks/__tests__/use-toast.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { reducer } from '../use-toast'
+
+describe('useToast reducer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('adds a toast', () => {
+    const state = { toasts: [] as any[] }
+    const toast = { id: '1', title: 'Hello', open: true }
+    const newState = reducer(state, { type: 'ADD_TOAST', toast })
+    expect(newState.toasts.length).toBe(1)
+    expect(newState.toasts[0]).toEqual(toast)
+  })
+
+  it('updates a toast', () => {
+    const state = { toasts: [{ id: '1', description: 'old', open: true }] }
+    const newState = reducer(state, { type: 'UPDATE_TOAST', toast: { id: '1', description: 'new' } })
+    expect(newState.toasts[0].description).toBe('new')
+  })
+
+  it('dismisses a toast', () => {
+    const state = { toasts: [{ id: '1', open: true }, { id: '2', open: true }] }
+    const newState = reducer(state, { type: 'DISMISS_TOAST', toastId: '1' })
+    expect(newState.toasts.find(t => t.id === '1')?.open).toBe(false)
+    expect(newState.toasts.find(t => t.id === '2')?.open).toBe(true)
+  })
+
+  it('removes a toast', () => {
+    const state = { toasts: [{ id: '1', open: true }, { id: '2', open: true }] }
+    const newState = reducer(state, { type: 'REMOVE_TOAST', toastId: '1' })
+    expect(newState.toasts).toHaveLength(1)
+    expect(newState.toasts[0].id).toBe('2')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,9 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true
   }
 })


### PR DESCRIPTION
## Summary
- add Vitest as a dev dependency and test script
- configure Vitest in `vite.config.ts`
- add tests for the toast reducer

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae215777c83289c9d357ab210a0da